### PR TITLE
Fix `grok` filter syntax

### DIFF
--- a/filter-10-audit.conf
+++ b/filter-10-audit.conf
@@ -1,8 +1,6 @@
 filter {
     grok {
-      match => "message" => [
-        "type=%{WORD:type} msg=audit\(%{NUMBER:timestamp}\.%{NUMBER:subsecond}:%{NUMBER:event_id}\): pid=%{NUMBER:pid} uid=%{NUMBER:uid} auid=%{NUMBER:auid} ses=%{NUMBER:ses} subj=%{DATA:subj} msg='op=%{DATA:operation} grantors=%{DATA:grantors} acct=\"%{DATA:acct}\" exe=\"%{DATA:exe}\" hostname=%{DATA:hostname} addr=%{DATA:addr} terminal=%{DATA:terminal} res=%{DATA:result}'"
-      ]
+      match => ["message","type=%{WORD:type} msg=audit\(%{NUMBER:timestamp}\.%{NUMBER:subsecond}:%{NUMBER:event_id}\): pid=%{NUMBER:pid} uid=%{NUMBER:uid} auid=%{NUMBER:auid} ses=%{NUMBER:ses} subj=%{DATA:subj} msg='op=%{DATA:operation} grantors=%{DATA:grantors} acct=\"%{DATA:acct}\" exe=\"%{DATA:exe}\" hostname=%{DATA:hostname} addr=%{DATA:addr} terminal=%{DATA:terminal} res=%{DATA:result}'"]
       overwrite => [ "message" ]
       add_tag => ["audit_events"]
 


### PR DESCRIPTION
Here's a proposal for a fix for your `filter` file.

It looks like you mixed up the two `grok` syntaxes. You have to choose between these two:
* `match => message => {"type=%{WORD..."}`
* `match => ["message","type=%{WORD..."]`

So either you use the double `=>` with `{}` brackets or you use a single `=>` and these `[]` brackets.